### PR TITLE
Fix: Support negative Unix timestamps in NetDate.UnmarshalJSON

### DIFF
--- a/dates.go
+++ b/dates.go
@@ -12,10 +12,13 @@ type NetDate struct {
 }
 
 func (s *NetDate) UnmarshalJSON(data []byte) error {
-	re := regexp.MustCompile("\\/Date\\(([0-9]*)\\+([0-9]*)\\)")
+	// The regular expression supports formats like /Date(-1234567890000+0000)/ or /Date(1234567890000+0000)/
+	// Capture only milliseconds, ignore offset
+	re := regexp.MustCompile(`\\/Date\((-?\d+)(?:\+\d+)?\)\\/`)
 	match := re.FindStringSubmatch(string(data))
 
-	if len(match) != 3 {
+	// match[0] - the whole string, match[1] - milliseconds
+	if len(match) != 2 {
 		return fmt.Errorf("invalid date format: %v", string(data))
 	}
 
@@ -25,9 +28,10 @@ func (s *NetDate) UnmarshalJSON(data []byte) error {
 
 	milliseconds, err := strconv.ParseInt(match[1], 10, 64)
 	if err != nil {
-		return fmt.Errorf("error parsing milliseconds: %v", match[1])
+		return fmt.Errorf("error parsing milliseconds %v: %w", match[1], err)
 	}
 
+	// Convert to time.Time, truncate to seconds and force to UTC
 	s.Time = time.Unix(int64(milliseconds/1000), 0).UTC()
 
 	return nil


### PR DESCRIPTION
This PR updates the NetDate.UnmarshalJSON method to support negative Unix timestamps in date strings returned by Xero, such as:
json
"\/Date(-2177452800000+0000)\/"
Previously, the regular expression only matched positive timestamps, which caused parsing to fail for historical dates (e.g., prior to 1970). 
This update:

Adds support for negative millisecond values using a more flexible regex.

Keeps the timezone offset part ignored, as Xero always returns UTC.

Adds proper validation to avoid panics on malformed data.